### PR TITLE
ported initialize from coach

### DIFF
--- a/initialize/README.md
+++ b/initialize/README.md
@@ -1,0 +1,5 @@
+# Initialize
+
+The init library container all of the functionality for the init command,
+used to create project configurations based on patterns or remote demo
+configurations.

--- a/initialize/default.go
+++ b/initialize/default.go
@@ -1,0 +1,40 @@
+package initialize
+
+import (
+	"github.com/james-nesbitt/wundertools-go/log"
+)
+
+func (tasks *InitTasks) Init_Default_Run(logger log.Log, source string) bool {
+
+	switch source {
+	case "bare":
+		fallthrough
+	default:
+		return tasks.Init_Default_Bare()
+	}
+
+	return false
+}
+
+func (tasks *InitTasks) Init_Default_Bare() bool {
+
+	tasks.AddFile(".wundertools/settings.yml", `# Wundertools project conf
+Project: bare`)
+	tasks.AddFile("docker-compose.yml", `# Project services
+`)
+	tasks.AddFile("app/README.md", `# Bare Project
+## /.wundertools/
+
+  Project wundertools configuration
+
+## /app
+
+  Project source-code and assets path
+
+`)
+
+	tasks.AddMessage("Created local project as a `bare` project")
+
+	return true
+}
+

--- a/initialize/file.go
+++ b/initialize/file.go
@@ -1,0 +1,352 @@
+package initialize
+
+import (
+	"io"
+	"os"
+	"os/user"
+	"path"
+	"strings"
+
+	"io/ioutil"
+	"net/http"
+
+	"github.com/james-nesbitt/wundertools-go/log"
+)
+
+type InitTaskFileBase struct {
+	root string
+}
+
+func (task *InitTaskFileBase) absolutePath(targetPath string, addRoot bool) (string, bool) {
+	if strings.HasPrefix(targetPath, "~") {
+		return path.Join(task.userHomePath(), targetPath[1:]), !addRoot
+
+		// I am not sure how reliable this function is
+		// you passed an absolute path, so I can't add the root
+		// } else if path.isAbs(targetPath) {
+		// 	return targetPath, !addRoot
+
+		// you passed a relative path, and want me to add the root
+	} else if addRoot {
+		return path.Join(task.root, targetPath), true
+
+		// you passed path and don't want the root added (but is it already abs?)
+	} else if targetPath != "" {
+		return targetPath, true
+
+		// you passed an empty string, and don't want the root added?
+	} else {
+		return targetPath, false
+	}
+}
+func (task *InitTaskFileBase) userHomePath() string {
+	if currentUser, err := user.Current(); err == nil {
+		return currentUser.HomeDir
+	} else {
+		return os.Getenv("HOME")
+	}
+}
+
+func (task *InitTaskFileBase) MakeDir(logger log.Log, makePath string, pathIsFile bool) bool {
+	if makePath == "" {
+		return true // it's already made
+	}
+
+	if pathDirectory, ok := task.absolutePath(makePath, true); !ok {
+		logger.Warning("Invalid directory path: " + pathDirectory)
+		return false
+	}
+	pathDirectory := path.Join(task.root, makePath)
+	if pathIsFile {
+		pathDirectory = path.Dir(pathDirectory)
+	}
+
+	if err := os.MkdirAll(pathDirectory, 0777); err != nil {
+		// @todo something log
+		return false
+	}
+	return true
+}
+func (task *InitTaskFileBase) MakeFile(logger log.Log, destinationPath string, contents string) bool {
+	if !task.MakeDir(logger, destinationPath, true) {
+		// @todo something log
+		return false
+	}
+
+	if destinationPath, ok := task.absolutePath(destinationPath, true); !ok {
+		logger.Warning("Invalid file destination path: " + destinationPath)
+		return false
+	}
+
+	fileObject, err := os.Create(destinationPath)
+	defer fileObject.Close()
+	if err != nil {
+		// @todo something log
+		return false
+	}
+	if _, err := fileObject.WriteString(contents); err != nil {
+		// @todo something log
+		return false
+	}
+
+	return true
+}
+
+func (task *InitTaskFileBase) CopyFile(logger log.Log, destinationPath string, sourcePath string) bool {
+	if destinationPath == "" || sourcePath == "" {
+		logger.Warning("empty source or destination passed for copy")
+		return false
+	}
+
+	sourcePath, ok := task.absolutePath(sourcePath, false)
+	if !ok {
+		logger.Warning("Invalid copy source path: " + sourcePath)
+		return false
+	}
+	sourceFile, err := os.Open(sourcePath)
+	if err != nil {
+		logger.Warning("could not copy file as it does not exist [" + sourcePath + "] : " + err.Error())
+		return false
+	}
+	defer sourceFile.Close()
+
+	if !task.MakeDir(logger, destinationPath, true) {
+		// @todo something log
+		logger.Warning("could not copy file as the path to the destination file could not be created [" + destinationPath + "]")
+		return false
+	}
+	destinationAbsPath, ok := task.absolutePath(destinationPath, true)
+	if !ok {
+		logger.Warning("Invalid copy destination path: " + destinationPath)
+		return false
+	}
+
+	destinationFile, err := os.Open(destinationAbsPath)
+	if err == nil {
+		logger.Warning("could not copy file as it already exists [" + destinationPath + "]")
+		destinationFile.Close()
+		return false
+	}
+
+	destinationFile, err = os.Create(destinationAbsPath)
+	if err != nil {
+		logger.Warning("could not copy file as destination file could not be created [" + destinationPath + "] : " + err.Error())
+		return false
+	}
+
+	defer destinationFile.Close()
+	_, err = io.Copy(destinationFile, sourceFile)
+
+	if err == nil {
+		sourceInfo, err := os.Stat(sourcePath)
+		if err == nil {
+			err = os.Chmod(destinationPath, sourceInfo.Mode())
+			return true
+		} else {
+			logger.Warning("could not copy file as destination file could not be created [" + destinationPath + "] : " + err.Error())
+			return false
+		}
+	} else {
+		logger.Warning("could not copy file as copy failed [" + destinationPath + "] : " + err.Error())
+	}
+
+	return true
+}
+
+func (task *InitTaskFileBase) CopyRemoteFile(logger log.Log, destinationPath string, sourcePath string) bool {
+	if destinationPath == "" || sourcePath == "" {
+		return false
+	}
+
+	response, err := http.Get(sourcePath)
+	if err != nil {
+		logger.Warning("Could not open remote URL: " + sourcePath)
+		return false
+	}
+	defer response.Body.Close()
+
+	sourceContent, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		logger.Warning("Could not read remote file: " + sourcePath)
+		return false
+	}
+
+	return task.MakeFile(logger, destinationPath, string(sourceContent))
+}
+
+func (task *InitTaskFileBase) CopyFileRecursive(logger log.Log, path string, source string) bool {
+	sourceAbsPath, ok := task.absolutePath(source, false)
+	if !ok {
+		logger.Warning("Couldn't find copy source " + source)
+		return false
+	}
+	return task.copyFileRecursive(logger, path, sourceAbsPath, "")
+}
+func (task *InitTaskFileBase) copyFileRecursive(logger log.Log, destinationRootPath string, sourceRootPath string, sourcePath string) bool {
+	fullPath := sourceRootPath
+
+	if sourcePath != "" {
+		fullPath = path.Join(fullPath, sourcePath)
+	}
+
+	// get properties of source dir
+	info,
+		err := os.Stat(fullPath)
+	if err != nil {
+		// @TODO do something log : source doesn't exist
+		logger.Warning("File does not exist :" + fullPath)
+		return false
+	}
+
+	mode := info.Mode()
+	if mode.IsDir() {
+
+		directory, _ := os.Open(fullPath)
+		objects, err := directory.Readdir(-1)
+
+		if err != nil {
+			// @TODO do something log : source doesn't exist
+			logger.Warning("Could not open directory")
+			return false
+		}
+
+		for _, obj := range objects {
+
+			//childSourcePath := source + "/" + obj.Name()
+			childSourcePath := path.Join(sourcePath, obj.Name())
+			if !task.copyFileRecursive(logger, destinationRootPath, sourceRootPath, childSourcePath) {
+				logger.Warning("Resursive copy failed")
+			}
+
+		}
+
+	} else {
+		// add file copy
+		destinationPath := path.Join(destinationRootPath, sourcePath)
+		if task.CopyFile(logger, destinationPath, sourceRootPath) {
+			logger.Info("--> Copied file (recursively): " + sourcePath + " [from " + sourceRootPath + "]")
+			return true
+		} else {
+			logger.Warning("--> Failed to copy file: " + sourcePath + " [from " + sourceRootPath + "]")
+			return false
+		}
+		return true
+	}
+	return true
+}
+
+// perform a string replace on file contents
+func (task *InitTaskFileBase) FileStringReplace(logger log.Log, targetPath string, oldString string, newString string, replaceCount int) bool {
+
+	targetPath, ok := task.absolutePath(targetPath, false)
+	if !ok {
+		logger.Warning("Invalid string replace path: " + targetPath)
+		return false
+	}
+
+	contents, err := ioutil.ReadFile(targetPath)
+	if err != nil {
+		logger.Error(err.Error())
+	}
+
+	contents = []byte(strings.Replace(string(contents), oldString, newString, replaceCount))
+
+	err = ioutil.WriteFile(targetPath, contents, 0644)
+	if err != nil {
+		logger.Error(err.Error())
+	}
+	return true
+}
+
+type InitTaskFile struct {
+	InitTaskFileBase
+	root string
+
+	path     string
+	contents string
+}
+
+func (task *InitTaskFile) RunTask(logger log.Log) bool {
+	if task.path == "" {
+		return false
+	}
+
+	if task.MakeFile(logger, task.path, task.contents) {
+		logger.Message("--> Created file : " + task.path)
+		return true
+	} else {
+		logger.Warning("--> Failed to create file : " + task.path)
+		return false
+	}
+}
+
+type InitTaskRemoteFile struct {
+	InitTaskFileBase
+	root string
+
+	path string
+	url  string
+}
+
+func (task *InitTaskRemoteFile) RunTask(logger log.Log) bool {
+	if task.path == "" || task.root == "" || task.url == "" {
+		return false
+	}
+
+	if task.CopyRemoteFile(logger, task.path, task.url) {
+		logger.Message("--> Copied remote file : " + task.url + " -> " + task.path)
+		return true
+	} else {
+		logger.Warning("--> Failed to copy remote file : " + task.url)
+		return false
+	}
+}
+
+type InitTaskFileCopy struct {
+	InitTaskFileBase
+	root string
+
+	path   string
+	source string
+}
+
+func (task *InitTaskFileCopy) RunTask(logger log.Log) bool {
+	if task.path == "" || task.root == "" || task.source == "" {
+		return false
+	}
+
+	if task.CopyFileRecursive(logger, task.path, task.source) {
+		logger.Message("--> Copied file : " + task.source + " -> " + task.path)
+		return true
+	} else {
+		logger.Warning("--> Failed to copy file : " + task.source + " -> " + task.path)
+		return false
+	}
+}
+
+type InitTaskFileStringReplace struct {
+	InitTaskFileBase
+	root string
+
+	path         string
+	oldString    string
+	newString    string
+	replaceCount int
+}
+
+func (task *InitTaskFileStringReplace) RunTask(logger log.Log) bool {
+	if task.path == "" || task.root == "" || task.oldString == "" || task.newString == "" {
+		return false
+	}
+	if task.replaceCount == 0 {
+		task.replaceCount = -1
+	}
+
+	if task.FileStringReplace(logger, task.path, task.oldString, task.newString, task.replaceCount) {
+		logger.Message("--> performed string replace on file : " + task.path)
+		return true
+	} else {
+		logger.Warning("--> Failed to perform string replace on file : " + task.path)
+		return false
+	}
+}

--- a/initialize/generate.go
+++ b/initialize/generate.go
@@ -1,0 +1,156 @@
+package initialize
+
+import (
+	"io"
+	"os"
+	"path"
+	"regexp"
+
+	"github.com/james-nesbitt/wundertools-go/log"
+)
+
+func Init_Generate(logger log.Log, handler string, path string, skip []string, sizeLimit int64, output io.Writer) bool {
+	logger.Message("GENERATING INIT")
+
+	var generator Generator
+	switch handler {
+	case "test":
+		generator = Generator(&TestInitGenerator{logger: logger, output: output})
+	case "yaml":
+		generator = Generator(&YMLInitGenerator{logger: logger, output: output})
+	default:
+		logger.Error("Unknown init generator (handler) " + handler)
+		return false
+	}
+
+	iterator := GenerateIterator{
+		logger:    logger,
+		output:    output,
+		skip:      skip,
+		sizeLimit: sizeLimit,
+		generator: generator,
+	}
+
+	if iterator.Generate(path) {
+		logger.Message("FINISHED GENERATING YML INIT")
+		return true
+	} else {
+		logger.Error("ERROR OCCURRED GENERATING YML INIT")
+		return false
+	}
+}
+
+type GenerateIterator struct {
+	logger log.Log
+	output io.Writer
+
+	skip      []string
+	sizeLimit int64
+
+	generator Generator
+}
+
+func (iterator *GenerateIterator) Generate(path string) bool {
+	return iterator.generate_Recursive(path, "")
+}
+func (iterator *GenerateIterator) generate_Recursive(sourceRootPath string, sourcePath string) bool {
+	fullPath := sourceRootPath
+
+	if sourcePath != "" {
+		fullPath = path.Join(fullPath, sourcePath)
+	}
+
+	for _, skipEach := range iterator.skip {
+		if match, _ := regexp.MatchString(skipEach, sourcePath); match {
+			iterator.logger.Info("Skipping marked skip file :" + sourcePath)
+			return true
+		}
+	}
+
+	// get properties of source dir
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		// @TODO do something log : source doesn't exist
+		iterator.logger.Warning("File does not exist :" + fullPath)
+		return false
+	}
+
+	mode := info.Mode()
+	if mode.IsDir() {
+
+		// check for GIT folder
+		if _, err := os.Open(path.Join(fullPath, ".git")); err == nil {
+			if iterator.generator.generateGit(fullPath, sourcePath) {
+				iterator.logger.Info("Generated git file: " + sourcePath)
+				return true
+			} else {
+				iterator.logger.Warning("Failed to generate git file: " + sourcePath)
+			}
+		}
+
+		directory, _ := os.Open(fullPath)
+		defer directory.Close()
+		objects, err := directory.Readdir(-1)
+
+		if err != nil {
+			// @TODO do something log : source doesn't exist
+			iterator.logger.Warning("Could not open directory")
+			return false
+		}
+
+		for _, obj := range objects {
+
+			//childSourcePath := source + "/" + obj.Name()
+			childSourcePath := path.Join(sourcePath, obj.Name())
+			if !iterator.generate_Recursive(sourceRootPath, childSourcePath) {
+				iterator.logger.Warning("Resursive generate failed")
+			}
+
+		}
+
+	} else if mode.IsRegular() {
+
+		if info.Size() > iterator.sizeLimit {
+			iterator.logger.Info("Skipped file that is larger than our limit: " + sourcePath)
+			return true
+		}
+
+		// generate single file from contents
+		if iterator.generator.generateSingleFile(fullPath, sourcePath) {
+			iterator.logger.Info("Generated file (recursively): " + sourcePath)
+			return true
+		} else {
+			iterator.logger.Warning("Failed to generate file: " + sourcePath)
+			return false
+		}
+		return true
+	} else {
+		iterator.logger.Warning("Skipped generation non-regular file: " + sourcePath)
+	}
+
+	return true
+}
+
+type Generator interface {
+	generateSingleFile(fullPath string, sourcePath string) bool
+	generateGit(fullPath string, sourcePath string) bool
+}
+
+type TestInitGenerator struct {
+	output io.Writer
+	logger log.Log
+}
+
+func (generator *TestInitGenerator) generateSingleFile(fullPath string, sourcePath string) bool {
+	singleFile, _ := os.Open(fullPath)
+	defer singleFile.Close()
+
+	generator.logger.Debug(log.VERBOSITY_DEBUG_LOTS, "GENERATE SINGLE FILE: ", singleFile.Name())
+	generator.output.Write([]byte("GENERATE SINGLE FILE: " + sourcePath + "\n"))
+	return true
+}
+func (generator *TestInitGenerator) generateGit(fullPath string, sourcePath string) bool {
+	generator.logger.Debug(log.VERBOSITY_DEBUG_LOTS, "GENERATE GIT FILE: ", sourcePath)
+	generator.output.Write([]byte("GENERATE GIT FILE: " + sourcePath + "\n"))
+	return true
+}

--- a/initialize/git.go
+++ b/initialize/git.go
@@ -1,0 +1,91 @@
+package initialize
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/james-nesbitt/wundertools-go/log"
+)
+
+func (tasks *InitTasks) Init_Git_Run(logger log.Log, source string) bool {
+
+	if source == "" {
+		logger.Error("You have not provided a git target $/> wundertools init git https://github.com/aleksijohansson/docker-drupal-coach")
+		return false
+	}
+
+	url := source
+	path := tasks.root
+
+	cmd := exec.Command("git", "clone", "--progress", url, path)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = logger
+	cmd.Stderr = logger
+
+	err := cmd.Start()
+
+	if err != nil {
+		logger.Error("Failed to clone the remote repository [" + url + "] => " + err.Error())
+		return false
+	}
+
+	logger.Message("Clone remote repository to local project folder [" + url + "]")
+	err = cmd.Wait()
+
+	if err != nil {
+		logger.Error("Failed to clone the remote repository [" + url + "] => " + err.Error())
+		return false
+	}
+
+	tasks.AddMessage("Cloned remote repository [" + url + "] to local project folder")
+	tasks.AddFile(".wundertools/CREATEDFROM.md", `THIS PROJECT WAS CREATED FROM GIT`)
+
+	return true
+}
+
+type InitTaskGitClone struct {
+	InitTaskFileBase
+	root string
+
+	path string
+	url  string
+}
+
+func (task *InitTaskGitClone) RunTask(logger log.Log) bool {
+	if task.root == "" || task.url == "" {
+		logger.Error("EMPTY ROOT PASSED TO GIT: " + task.root)
+		return false
+	}
+
+	destinationPath := task.path
+	url := task.url
+
+	if !task.MakeDir(logger, destinationPath, false) {
+		return false
+	}
+
+	destinationAbsPath, ok := task.absolutePath(destinationPath, true)
+	if !ok {
+		logger.Warning("Invalid copy destination path: " + destinationPath)
+		return false
+	}
+
+	cmd := exec.Command("git", "clone", "--progress", url, destinationAbsPath)
+	cmd.Stderr = logger
+	err := cmd.Start()
+
+	if err != nil {
+		logger.Error("Failed to clone the remote repository [" + url + "] => " + err.Error())
+		return false
+	}
+
+	err = cmd.Wait()
+
+	if err != nil {
+		logger.Error("Failed to clone the remote repository [" + url + "] => " + err.Error())
+		return false
+	}
+
+	logger.Message("Cloned remote repository [" + url + "] to local path " + destinationPath)
+	return true
+}

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -1,0 +1,97 @@
+package initialize
+
+import (
+	"github.com/james-nesbitt/wundertools-go/log"
+)
+
+type InitTasks struct {
+	root string
+
+	tasks []InitTask
+}
+
+func (tasks *InitTasks) Init(logger log.Log, root string) bool {
+	tasks.root = root
+	tasks.tasks = []InitTask{}
+	return true
+}
+func (tasks *InitTasks) RunTasks(logger log.Log) {
+	for _, task := range tasks.tasks {
+		logger.Debug(log.VERBOSITY_DEBUG_LOTS, "INIT TASK:", task)
+		task.RunTask(logger)
+	}
+}
+
+func (tasks *InitTasks) AddTask(task InitTask) {
+	tasks.tasks = append(tasks.tasks, task)
+}
+
+func (tasks *InitTasks) AddFile(path string, contents string) {
+	tasks.AddTask(InitTask(&InitTaskFile{
+		root:     tasks.root,
+		path:     path,
+		contents: contents,
+	}))
+}
+func (tasks *InitTasks) AddRemoteFile(path string, url string) {
+	tasks.AddTask(InitTask(&InitTaskRemoteFile{
+		root: tasks.root,
+		path: path,
+		url:  url,
+	}))
+}
+func (tasks *InitTasks) AddFileCopy(path string, source string) {
+	tasks.AddTask(InitTask(&InitTaskFileCopy{
+		root:   tasks.root,
+		path:   path,
+		source: source,
+	}))
+}
+func (tasks *InitTasks) AddFileStringReplace(path string, oldString string, newString string, replaceCount int) {
+	tasks.AddTask(InitTask(&InitTaskFileStringReplace{
+		root:         tasks.root,
+		path:         path,
+		oldString:    oldString,
+		newString:    newString,
+		replaceCount: replaceCount,
+	}))
+}
+func (tasks *InitTasks) AddGitClone(path string, url string) {
+	tasks.AddTask(InitTask(&InitTaskGitClone{
+		root: tasks.root,
+		path: path,
+		url:  url,
+	}))
+}
+func (tasks *InitTasks) AddMessage(message string) {
+	tasks.AddTask(InitTask(&InitTaskMessage{
+		message: message,
+	}))
+}
+func (tasks *InitTasks) AddError(error string) {
+	tasks.AddTask(InitTask(&InitTaskError{
+		error: error,
+	}))
+}
+
+type InitTask interface {
+	RunTask(logger log.Log) bool
+}
+
+type InitTaskError struct {
+	error string
+}
+
+func (task *InitTaskError) RunTask(logger log.Log) bool {
+	logger.Error(task.error)
+	return true
+}
+
+type InitTaskMessage struct {
+	message string
+}
+
+func (task *InitTaskMessage) RunTask(logger log.Log) bool {
+	logger.Message(task.message)
+	return true
+}

--- a/initialize/yaml.go
+++ b/initialize/yaml.go
@@ -1,0 +1,204 @@
+package initialize
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"encoding/json"
+	"gopkg.in/yaml.v2"
+
+	"github.com/james-nesbitt/coach/log"
+)
+
+// Get tasks from remote YAML corresponding to a remote yaml file
+func (tasks *InitTasks) Init_Yaml_Run(logger log.Log, path string) bool {
+
+	var yamlSourceBytes []byte
+	var err error
+
+	if strings.Contains(path, "://") {
+
+		resp, err := http.Get(path)
+		if err != nil {
+			logger.Error("Could not retrieve remote yaml init instructions [" + path + "] : " + err.Error())
+			return false
+		}
+		defer resp.Body.Close()
+		yamlSourceBytes, err = ioutil.ReadAll(resp.Body)
+
+	} else {
+
+		// read the config file
+		yamlSourceBytes, err = ioutil.ReadFile(path)
+		if err != nil {
+			logger.Error("Could not read the local YAML file [" + path + "]: " + err.Error())
+			return false
+		}
+		if len(yamlSourceBytes) == 0 {
+			logger.Error("Yaml file [" + path + "] was empty")
+			return false
+		}
+
+	}
+
+	tasks.AddMessage("Initializing using YAML Source [" + path + "] to local project folder")
+
+	// get tasks from yaml
+	tasks.AddTasksFromYaml(logger, yamlSourceBytes)
+
+	// Add some message items
+	tasks.AddFile(".wundertools/CREATEDFROM.md", "THIS PROJECT WAS CREATED A COACH YAML INSTALLER :"+path)
+
+	return true
+}
+
+/**
+ *Getting tasks from YAML
+ */
+
+func (tasks *InitTasks) AddTasksFromYaml(logger log.Log, yamlSource []byte) error {
+
+	var yaml_tasks []map[string]interface{}
+	err := yaml.Unmarshal(yamlSource, &yaml_tasks)
+	if err != nil {
+		return err
+	}
+
+	var taskAdder TaskAdder
+	for _, task_struct := range yaml_tasks {
+
+		taskAdder = nil
+
+		if _, ok := task_struct["Type"]; !ok {
+			continue
+		}
+
+		switch task_struct["Type"] {
+		case "File":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_FileMake
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+		case "RemoteFile":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_RemoteFileCopy
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+		case "FileCopy":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_FileCopy
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+		case "FileStringReplace":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_FileStringReplace
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+		case "GitClone":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_GitClone
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+		case "Message":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_Message
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+		case "Error":
+			json_task, _ := json.Marshal(task_struct)
+			var task InitTaskYaml_Error
+			if err := json.Unmarshal(json_task, &task); err == nil {
+				taskAdder = TaskAdder(&task)
+			}
+
+		default:
+			taskType := task_struct["Type"].(string)
+			logger.Warning("Unknown init task type [" + taskType + "]")
+		}
+
+		if taskAdder != nil {
+			taskAdder.AddTask(tasks)
+		}
+
+	}
+
+	return nil
+}
+
+type InitTaskYaml_Base struct {
+	Type string `json:"Type" yaml:"Type"`
+}
+
+type TaskAdder interface {
+	AddTask(tasks *InitTasks)
+}
+
+type InitTaskYaml_FileMake struct {
+	Path     string `json:"Path" yaml:"Path"`
+	Contents string `json:"Contents" yaml:"Contents"`
+}
+
+func (task *InitTaskYaml_FileMake) AddTask(tasks *InitTasks) {
+	tasks.AddFile(task.Path, task.Contents)
+}
+
+type InitTaskYaml_RemoteFileCopy struct {
+	Path string `json:"Path" yaml:"Path"`
+	Url  string `json:"Url" yaml:"Url"`
+}
+
+func (task *InitTaskYaml_RemoteFileCopy) AddTask(tasks *InitTasks) {
+	tasks.AddRemoteFile(task.Path, task.Url)
+}
+
+type InitTaskYaml_FileCopy struct {
+	Path   string `json:"Path" yaml:"Path"`
+	Source string `json:"Source" yaml:"Source"`
+}
+
+func (task *InitTaskYaml_FileCopy) AddTask(tasks *InitTasks) {
+	tasks.AddFileCopy(task.Path, task.Source)
+}
+
+type InitTaskYaml_FileStringReplace struct {
+	Path         string `json:"Path" yaml:"Path"`
+	OldString    string `json:"Old" yaml:"Source"`
+	NewString    string `json:"New" yaml:"Source"`
+	ReplaceCount int    `json:"Limit" yaml:"Source"`
+}
+
+func (task *InitTaskYaml_FileStringReplace) AddTask(tasks *InitTasks) {
+	tasks.AddFileStringReplace(task.Path, task.OldString, task.NewString, task.ReplaceCount)
+}
+
+type InitTaskYaml_GitClone struct {
+	Path string `json:"Path" yaml:"Path"`
+	Url  string `json:"Url" yaml:"Url"`
+}
+
+func (task *InitTaskYaml_GitClone) AddTask(tasks *InitTasks) {
+	tasks.AddGitClone(task.Path, task.Url)
+}
+
+type InitTaskYaml_Message struct {
+	Message string `json:"Message" yaml:"Message"`
+}
+
+func (task *InitTaskYaml_Message) AddTask(tasks *InitTasks) {
+	tasks.AddMessage(task.Message)
+}
+
+type InitTaskYaml_Error struct {
+	Error string `json:"Error" yaml:"Error"`
+}
+
+func (task *InitTaskYaml_Error) AddTask(tasks *InitTasks) {
+	tasks.AddError(task.Error)
+}

--- a/initialize/yaml_generate.go
+++ b/initialize/yaml_generate.go
@@ -1,0 +1,77 @@
+package initialize
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/james-nesbitt/wundertools-go/log"
+)
+
+type YMLInitGenerator struct {
+	output io.Writer
+	logger log.Log
+}
+
+func (generator *YMLInitGenerator) generateSingleFile(fullPath string, sourcePath string) bool {
+	singleFile, _ := os.Open(fullPath)
+	defer singleFile.Close()
+
+	generator.logger.Debug(log.VERBOSITY_DEBUG_LOTS, "GENERATE SINGLE FILE: ", singleFile.Name())
+	generator.output.Write([]byte("- Type: File\n"))
+	generator.output.Write([]byte("  Path: " + sourcePath + "\n"))
+	generator.output.Write([]byte("  Contents: |\n"))
+
+	r := bufio.NewReader(singleFile)
+	for {
+		line, err := r.ReadString(10) // 0x0A separator = newline
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			generator.logger.Error(err.Error())
+			return false // if you return error
+		}
+		generator.output.Write([]byte("    " + line))
+	}
+	return true
+}
+func (generator *YMLInitGenerator) generateGit(fullPath string, sourcePath string) bool {
+
+	gitUrl := ""
+
+	if configFile, err := os.Open(path.Join(fullPath, ".git", "config")); err == nil {
+
+		r := bufio.NewReader(configFile)
+		for {
+			line, err := r.ReadString(10) // 0x0A separator = newline
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				generator.logger.Error(err.Error())
+				return false // if you return error
+			}
+			if strings.Contains(line, "url =") {
+				lineSplit := strings.Split(line, "url =")
+				gitUrl = strings.Trim(lineSplit[len(lineSplit)-1], " ")
+				break
+			}
+		}
+
+	} else {
+		generator.logger.Error("Could not open .git/config in " + sourcePath)
+		return false
+	}
+
+	if gitUrl == "" {
+		generator.logger.Error("Could not determine GIT Url from .git/config")
+		return false
+	}
+
+	generator.logger.Debug(log.VERBOSITY_DEBUG_LOTS, "GENERATE GIT FILE: ", sourcePath)
+	generator.output.Write([]byte("- Type: GitClone\n"))
+	generator.output.Write([]byte("  Path: " + sourcePath + "\n"))
+	generator.output.Write([]byte("  Url: " + gitUrl + "\n"))
+	return true
+}

--- a/operation/init.go
+++ b/operation/init.go
@@ -1,0 +1,62 @@
+package operation
+
+import (
+	// "github.com/james-nesbitt/wundertools-go/config"
+ 	// "github.com/james-nesbitt/wundertools-go/log"
+ 	"github.com/james-nesbitt/wundertools-go/initialize"
+)
+
+type Init struct {
+	BaseOperation
+}
+
+func (operation *Init) Execute(flags ...string) {
+
+	var method string = "bare"
+	var source string = "" // has context based on type
+
+	if len(flags)>0 {
+		switch flags[0] {
+		case "git":
+			method = "git"
+			if len(flags)>1 {
+				source = flags[0]
+			} else {
+				operation.logger.Error("No git repository provided.")
+			}
+		case "yml":
+			method = "yml"
+
+			if len(flags)>1 {
+				source = flags[0]
+			} else {
+				operation.logger.Error("No yml source provided.")
+			}
+		}
+
+	} else {
+		operation.logger.Warning("No operation was passed to the compose operation. A bare project will be created.")
+	}
+
+	if rootpath, ok := operation.application.Path("project-root"); !ok {
+		operation.logger.Error("No project root path has been defined, so no project can be initialized.")
+		return
+	} else {
+
+		initTasks := initialize.InitTasks{}
+		initTasks.Init(operation.logger, rootpath)
+
+		switch method {
+		case "git":
+			operation.logger.Info("Creating project from git")
+			initTasks.Init_Git_Run(operation.logger, source)
+		case "bare":
+			operation.logger.Info("Creating bare project")
+			initTasks.Init_Default_Bare()
+		}
+
+		initTasks.RunTasks(operation.logger)
+
+	}
+
+}

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -13,6 +13,9 @@ func GetOperation(name string) (Operation, bool) {
 	case "compose":
 		operation := Compose{}
 		return Operation(&operation), true
+	case "init":
+		operation := Init{}
+		return Operation(&operation), true
 	}
 	return nil, false
 }


### PR DESCRIPTION
Ported some of the coach init functionality to this tool. This allows the following behaviours:
- create a new project from a git clone
- create a new project based on a yml file template (there is an equivalent generate command)
- create a new bare project (built in template)

The yml method is the best option, as the bar project is quite empty, and the git method is something that can be done without the tool.

The yml method allows:
- package the yml into any distributable string resource: e.g. gist, in repository file, file from any remote source (http/ftp/curl/local)
- combine complex project arrangments in a single file definition.

To Use:

bare project

```
$/> wundertools-go init
```

Project from yml

```
$/> wundertools-go yml http://path.to/my.yml
```

TODO:
- create the set of useful demo yml templats, as coach has.
- create a demo method: $/> wundertools-go init demo drupal8
