### PR TITLE
added compose start and stop commands

### DIFF
--- a/compose/start.go
+++ b/compose/start.go
@@ -1,0 +1,12 @@
+package compose
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+func (project *ComposeProject) Start() {
+	if err := project.APIProject.Start(context.Background()); err != nil {
+		log.WithError(err).Fatal("Could not start the project.")
+	}
+}

--- a/compose/stop.go
+++ b/compose/stop.go
@@ -1,0 +1,12 @@
+package compose
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+func (project *ComposeProject) Stop(timeout int) {
+	if err := project.APIProject.Stop(context.Background(), timeout); err != nil {
+		log.WithError(err).Fatal("Could not stop the project.")
+	}
+}

--- a/operation/compose.go
+++ b/operation/compose.go
@@ -29,6 +29,12 @@ func (operation *Compose) Execute(flags ...string) {
 		case "down":
 			log.Debug("Upping project")
 			operation.execute_Down(composeProject, flags...)
+		case "start":
+			log.Debug("Upping project")
+			operation.execute_Start(composeProject, flags...)
+		case "stop":
+			log.Debug("Upping project")
+			operation.execute_Stop(composeProject, flags...)
 
 		case "info":
 			log.Debug("Project information")
@@ -41,6 +47,7 @@ func (operation *Compose) Execute(flags ...string) {
 
 }
 
+// Parse flags and interpret a compose up
 func (operation *Compose) execute_Up(composeProject *compose.ComposeProject, flags ...string) {
 	NoRecreate := false
 	ForceRecreate := false
@@ -64,6 +71,7 @@ func (operation *Compose) execute_Up(composeProject *compose.ComposeProject, fla
 	composeProject.Up(NoRecreate, ForceRecreate, NoBuild)
 }
 
+// Parse flags and interpret a compose down
 func (operation *Compose) execute_Down(composeProject *compose.ComposeProject, flags ...string) {
 	RemoveVolume := false
 	RemoveImages := ""
@@ -85,4 +93,23 @@ func (operation *Compose) execute_Down(composeProject *compose.ComposeProject, f
 	}
 
 	composeProject.Down(RemoveVolume, RemoveImages, RemoveOrphans)
+}
+
+// Parse flags and interpret a compose start
+func (operation *Compose) execute_Start(composeProject *compose.ComposeProject, flags ...string) {
+	composeProject.Start()
+}
+
+// Parse flags and interpret a compose stop
+func (operation *Compose) execute_Stop(composeProject *compose.ComposeProject, flags ...string) {
+	timeout := 10
+
+	for _, flag := range flags {
+		switch flag {
+		case "--quick":
+			timeout = 1
+		}
+	}
+
+	composeProject.Stop(timeout)
 }


### PR DESCRIPTION
This patch adds new compose commands for starting and stopping services.

```
$/> wundertools-go compose start
$/> wundertools-go compose stop
$/> wundertools-go compose stop --quick
```
