### PR TITLE
added compose log operation to attach to container output

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -3,6 +3,8 @@ package command
 import (
 	"github.com/james-nesbitt/wundertools-go/compose"
 	"github.com/james-nesbitt/wundertools-go/config"
+
+	libCompose_logger "github.com/docker/libcompose/logger"
 )
 
 // Determine if the string corresponds to a command name,
@@ -69,5 +71,5 @@ func (command *CommandBase) Prepare(name string, allCommands *Commands) {
 }
 func (command *CommandBase) Init(application *config.Application) {
 	command.application = application
-	command.project, _ = compose.MakeComposeProject(application)
+	command.project, _ = compose.MakeComposeProject(application, libCompose_logger.Factory(&libCompose_logger.RawLogger{}))
 }

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -12,12 +12,13 @@ import (
 
 	// libCompose_config "github.com/docker/libcompose/config"
 	libCompose_docker "github.com/docker/libcompose/docker"
+	libCompose_logger "github.com/docker/libcompose/logger"
 	libCompose_project "github.com/docker/libcompose/project"
 
 	"github.com/james-nesbitt/wundertools-go/config"
 )
 
-func MakeComposeProject(application *config.Application) (*ComposeProject, bool) {
+func MakeComposeProject(application *config.Application, logger libCompose_logger.Factory) (*ComposeProject, bool) {
 
 	composeProjectName := application.Name
 	composeFiles := []string{}
@@ -33,6 +34,11 @@ func MakeComposeProject(application *config.Application) (*ComposeProject, bool)
 			ProjectName:  composeProjectName,
 		},
 	}
+
+	if logger != nil {
+		context.LoggerFactory = logger
+	}
+
 	project, err := libCompose_docker.NewProject(context, nil)
 
 	if err != nil {

--- a/compose/info.go
+++ b/compose/info.go
@@ -6,13 +6,14 @@ package compose
 
 import (
 	"strings"
+	// "strconv"
 	"text/tabwriter"
 
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 	// "github.com/james-nesbitt/wundertools-go/config"
 	// "github.com/docker/libcompose/docker"
-	// libCompose_project "github.com/docker/libcompose/project"
+	libCompose_project "github.com/docker/libcompose/project"
 )
 
 // main info method
@@ -48,8 +49,26 @@ func (project *ComposeProject) info_nodes() {
 	for _, serviceName := range project.serviceNames() {
 
 		service, _ := project.CreateService(serviceName)
+		infoSet, _ := service.Info(context.Background())
 		containers, _ := service.Containers(ctx)
 		config := service.Config()
+
+		var info libCompose_project.Info
+		if len(infoSet) > 0 {
+			info = infoSet[0]
+		} else {
+			info = libCompose_project.Info{}
+		}
+
+		if _, ok := info["State"]; !ok {
+			info["State"] = ""
+		}
+		// infoString := ""
+		// for index, info := range infoSet {
+		// 	for key, value := range info {
+		// 		infoString += strconv.FormatInt(int64(index), 10)+":"+key+"="+value+"|"
+		// 	}
+		// }
 
 		var row []string
 
@@ -57,6 +76,8 @@ func (project *ComposeProject) info_nodes() {
 			"|-",
 			service.Name(),
 			config.Image,
+			"",
+			info["State"],
 			// 	image.ID[:11],
 			// 	strings.Join(image.RepoTags, ","),
 			// 	strconv.FormatInt(image.Created, 10),

--- a/compose/log.go
+++ b/compose/log.go
@@ -1,0 +1,12 @@
+package compose
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+func (project *ComposeProject) Log(follow bool) {
+	if err := project.APIProject.Log(context.TODO(), follow); err != nil {
+		log.WithError(err).Fatal("Could not start the project.")
+	}
+}

--- a/initialize/generate.go
+++ b/initialize/generate.go
@@ -64,7 +64,7 @@ func (iterator *GenerateIterator) generate_Recursive(sourceRootPath string, sour
 
 	for _, skipEach := range skip {
 		if match, _ := regexp.MatchString(skipEach, sourcePath); match {
-			log.WithFields(log.Fields{"path": sourcePath}).Info("Skipping marked skip file.")
+			log.WithFields(log.Fields{"path": sourcePath}).Info("Skipping marked skip item.")
 			return true
 		}
 	}
@@ -105,7 +105,7 @@ func (iterator *GenerateIterator) generate_Recursive(sourceRootPath string, sour
 						continue
 					}
 
-					log.WithFields(log.Fields{"skip": text, "ignoreSource": ignoreFileName, "path": fullPath}).Info("add ignore item to skip list")
+					log.WithFields(log.Fields{"skip": text, "file": ignoreFileName, "path": fullPath}).Info("add ignore item to skip list")
 					skip = append(skip, strings.TrimSpace(text))
 				}
 

--- a/operation/compose.go
+++ b/operation/compose.go
@@ -4,6 +4,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/james-nesbitt/wundertools-go/compose"
+
+	libCompose_logger "github.com/docker/libcompose/logger"
 )
 
 type Compose struct {
@@ -12,7 +14,7 @@ type Compose struct {
 
 func (operation *Compose) Execute(flags ...string) {
 
-	composeProject, ok := compose.MakeComposeProject(operation.application)
+	composeProject, ok := compose.MakeComposeProject(operation.application, libCompose_logger.Factory(&libCompose_logger.RawLogger{}))
 	if !ok {
 		log.Error("could not build compose project")
 		return
@@ -35,6 +37,10 @@ func (operation *Compose) Execute(flags ...string) {
 		case "stop":
 			log.Debug("Upping project")
 			operation.execute_Stop(composeProject, flags...)
+
+		case "log":
+			log.Debug("Outputting log for project")
+			operation.execute_Log(composeProject, flags...)
 
 		case "info":
 			log.Debug("Project information")
@@ -112,4 +118,18 @@ func (operation *Compose) execute_Stop(composeProject *compose.ComposeProject, f
 	}
 
 	composeProject.Stop(timeout)
+}
+
+// Parse flags and interpret a compose log
+func (operation *Compose) execute_Log(composeProject *compose.ComposeProject, flags ...string) {
+	follow := false
+
+	for _, flag := range flags {
+		switch flag {
+		case "--follow":
+			follow = true
+		}
+	}
+
+	composeProject.Log(follow)
 }

--- a/operation/info.go
+++ b/operation/info.go
@@ -4,6 +4,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/james-nesbitt/wundertools-go/compose"
+
+	libCompose_logger "github.com/docker/libcompose/logger"
 )
 
 type Info struct {
@@ -23,7 +25,7 @@ func (operation *Info) Execute(flags ...string) {
 	// logger.Debug(log.VERBOSITY_MESSAGE, "Conf Path keys:", app.Paths.OrderedConfPathKeys())
 	// logger.Debug(log.VERBOSITY_MESSAGE, "Project Paths:", app.Paths)
 
-	composeProject, ok := compose.MakeComposeProject(app)
+	composeProject, ok := compose.MakeComposeProject(app, libCompose_logger.Factory(&libCompose_logger.RawLogger{}))
 	if !ok {
 		log.Error("could not build compose project")
 		return


### PR DESCRIPTION
This patch adds more verbose logging across the application, and adds an operation for docker-compose logs.

The more verbose logging is required to enable log output from the logs command
