### PR TITLE
switch logging to custom logger

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -3,8 +3,6 @@ package command
 import (
 	"github.com/james-nesbitt/wundertools-go/compose"
 	"github.com/james-nesbitt/wundertools-go/config"
-
-	libCompose_logger "github.com/docker/libcompose/logger"
 )
 
 // Determine if the string corresponds to a command name,
@@ -71,5 +69,5 @@ func (command *CommandBase) Prepare(name string, allCommands *Commands) {
 }
 func (command *CommandBase) Init(application *config.Application) {
 	command.application = application
-	command.project, _ = compose.MakeComposeProject(application, libCompose_logger.Factory(&libCompose_logger.RawLogger{}))
+	command.project, _ = compose.MakeComposeProject(application, compose.NewWundertoolsLoggerFactory())
 }

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -35,7 +35,9 @@ func MakeComposeProject(application *config.Application, logger libCompose_logge
 		},
 	}
 
-	if logger != nil {
+	if logger == nil {
+		context.LoggerFactory = NewWundertoolsLoggerFactory()
+	} else {
 		context.LoggerFactory = logger
 	}
 

--- a/compose/logger.go
+++ b/compose/logger.go
@@ -1,0 +1,81 @@
+package compose
+
+import (
+	"errors"
+	"io"
+
+	log "github.com/Sirupsen/logrus"
+
+	libCompose_logger "github.com/docker/libcompose/logger"
+)
+
+func NewWundertoolsLoggerFactory() libCompose_logger.Factory {
+	factory := WundertoolsComposerLoggerFactory{}
+
+	return libCompose_logger.Factory(&factory)
+}
+
+type WundertoolsComposerLoggerFactory struct {
+}
+
+func (factory *WundertoolsComposerLoggerFactory) CreateContainerLogger(name string) libCompose_logger.Logger {
+	return factory.createLogger("[" + name + "]-->")
+}
+func (factory *WundertoolsComposerLoggerFactory) CreateBuildLogger(name string) libCompose_logger.Logger {
+	return factory.createLogger("BUILD [" + name + "]-->")
+}
+func (factory *WundertoolsComposerLoggerFactory) CreatePullLogger(name string) libCompose_logger.Logger {
+	return factory.createLogger("PULL [" + name + "]-->")
+}
+
+func (factory *WundertoolsComposerLoggerFactory) createLogger(prefix string) libCompose_logger.Logger {
+	return libCompose_logger.Logger(&WundertoolsComposerLogger{
+		Prefix:    prefix,
+		outWriter: &WundertoolsComposerLogger_Writer{Type: "out", Prefix: prefix},
+		errWriter: &WundertoolsComposerLogger_Writer{Type: "err", Prefix: prefix},
+	})
+}
+
+type WundertoolsComposerLogger struct {
+	Prefix    string
+	outWriter *WundertoolsComposerLogger_Writer
+	errWriter *WundertoolsComposerLogger_Writer
+}
+
+func (logger *WundertoolsComposerLogger) Out(bytes []byte) {
+	logger.outWriter.Write(bytes)
+}
+func (logger *WundertoolsComposerLogger) Err(bytes []byte) {
+	logger.errWriter.Write(bytes)
+}
+
+func (logger *WundertoolsComposerLogger) OutWriter() io.Writer {
+	return io.Writer(logger.outWriter)
+}
+func (logger *WundertoolsComposerLogger) ErrWriter() io.Writer {
+	return io.Writer(logger.errWriter)
+}
+
+type WundertoolsComposerLogger_Writer struct {
+	Type   string
+	Prefix string
+}
+
+func (writer *WundertoolsComposerLogger_Writer) Write(bytes []byte) (int, error) {
+	// if the message ends in a /n, remove it
+	if bytes[len(bytes)-1] == 10 {
+		bytes = bytes[0 : len(bytes)-1]
+	}
+
+	message := writer.Prefix + string(bytes)
+
+	switch writer.Type {
+	case "out":
+		log.Info(message)
+		return len(bytes), nil
+	case "err":
+		log.Error(message)
+		return len(bytes), nil
+	}
+	return 0, errors.New("wrong writer type")
+}

--- a/operation/compose.go
+++ b/operation/compose.go
@@ -4,8 +4,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/james-nesbitt/wundertools-go/compose"
-
-	libCompose_logger "github.com/docker/libcompose/logger"
 )
 
 type Compose struct {
@@ -14,7 +12,7 @@ type Compose struct {
 
 func (operation *Compose) Execute(flags ...string) {
 
-	composeProject, ok := compose.MakeComposeProject(operation.application, libCompose_logger.Factory(&libCompose_logger.RawLogger{}))
+	composeProject, ok := compose.MakeComposeProject(operation.application, compose.NewWundertoolsLoggerFactory())
 	if !ok {
 		log.Error("could not build compose project")
 		return

--- a/operation/info.go
+++ b/operation/info.go
@@ -4,8 +4,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/james-nesbitt/wundertools-go/compose"
-
-	libCompose_logger "github.com/docker/libcompose/logger"
 )
 
 type Info struct {
@@ -25,7 +23,7 @@ func (operation *Info) Execute(flags ...string) {
 	// logger.Debug(log.VERBOSITY_MESSAGE, "Conf Path keys:", app.Paths.OrderedConfPathKeys())
 	// logger.Debug(log.VERBOSITY_MESSAGE, "Project Paths:", app.Paths)
 
-	composeProject, ok := compose.MakeComposeProject(app, libCompose_logger.Factory(&libCompose_logger.RawLogger{}))
+	composeProject, ok := compose.MakeComposeProject(app, compose.NewWundertoolsLoggerFactory())
 	if !ok {
 		log.Error("could not build compose project")
 		return


### PR DESCRIPTION
This patch introduces a new custom logger, which has better logging output, and can now be used as the basis for custom logging output from Docker containers.
