### PR TITLE
refactored properties to make them easier to use

### DIFF
--- a/api/handler/bytesource/property.go
+++ b/api/handler/bytesource/property.go
@@ -33,6 +33,16 @@ func (filesettings *BytesourceFilesettingsProperty) Description() string {
 	return "Filebased bytesource paths configuration object."
 }
 
+// Is the Property internal only
+func (filesettings *BytesourceFilesettingsProperty) Internal() bool {
+	return false
+}
+
+// Give an idea of what type of value the property consumes
+func (filesettings *BytesourceFilesettingsProperty) Type() string {
+	return "handler/bytesource.BytesourceFileSettings"
+}
+
 func (filesettings *BytesourceFilesettingsProperty) Get() interface{} {
 	return interface{}(filesettings.value)
 }

--- a/api/handler/libcompose/property.go
+++ b/api/handler/libcompose/property.go
@@ -65,6 +65,11 @@ func (name *LibcomposeProjectnameProperty) Description() string {
 	return "Compose project name, which is used in container, volume and network naming."
 }
 
+// Is the Property internal only
+func (name *LibcomposeProjectnameProperty) Internal() bool {
+	return false
+}
+
 // YAML file list Property for a docker.libCompose project
 type LibcomposeComposefilesProperty struct {
 	operation.StringSliceProperty
@@ -83,6 +88,11 @@ func (files *LibcomposeComposefilesProperty) Label() string {
 // Description for the Property
 func (files *LibcomposeComposefilesProperty) Description() string {
 	return "An ordered list of docker-compose yml files, which are passed to libcompose."
+}
+
+// Is the Property internal only
+func (files *LibcomposeComposefilesProperty) Internal() bool {
+	return false
 }
 
 // A libcompose Property for net context limiting
@@ -105,6 +115,11 @@ func (contextConf *LibcomposeContextProperty) Description() string {
 	return "A golang.org/x/net/context for controling execution."
 }
 
+// Is the Property internal only
+func (contextConf *LibcomposeContextProperty) Internal() bool {
+	return false
+}
+
 // Output handler Property for a docker.libCompose project
 type LibcomposeOutputProperty struct {
 	operation.WriterProperty
@@ -125,6 +140,11 @@ func (output *LibcomposeOutputProperty) Description() string {
 	return "Output io.Writer which will receive compose output from containers."
 }
 
+// Is the Property internal only
+func (output *LibcomposeOutputProperty) Internal() bool {
+	return false
+}
+
 // Error handler Property for a docker.libCompose project
 type LibcomposeErrorProperty struct {
 	operation.WriterProperty
@@ -143,6 +163,11 @@ func (err *LibcomposeErrorProperty) Label() string {
 // Description for the Property
 func (err *LibcomposeErrorProperty) Description() string {
 	return "Error io.Writer which will receive compose output from containers."
+}
+
+// Is the Property internal only
+func (err *LibcomposeErrorProperty) Internal() bool {
+	return false
 }
 
 /**
@@ -170,6 +195,11 @@ func (follow *LibcomposeAttachFollowProperty) Description() string {
 	return "When capturing output, stay attached and follow the output?"
 }
 
+// Is the Property internal only
+func (follow *LibcomposeAttachFollowProperty) Internal() bool {
+	return false
+}
+
 // A libcompose Property for net context limiting
 type LibcomposeOptionsUpProperty struct {
 	value libCompose_options.Up
@@ -188,6 +218,16 @@ func (optionsConf *LibcomposeOptionsUpProperty) Label() string {
 // Description for the Property
 func (optionsConf *LibcomposeOptionsUpProperty) Description() string {
 	return "Options to configure the Up.  See github.com/docker/libcompose/project/options for more information."
+}
+
+// Is the Property internal only
+func (optionsConf *LibcomposeOptionsUpProperty) Internal() bool {
+	return false
+}
+
+// Give an idea of what type of value the property consumes
+func (optionsConf *LibcomposeOptionsUpProperty) Type() string {
+	return "github.com/docker/libcompose/project/options.Up"
 }
 
 func (optionsConf *LibcomposeOptionsUpProperty) Get() interface{} {
@@ -221,6 +261,16 @@ func (optionsConf *LibcomposeOptionsDownProperty) Label() string {
 // Description for the Property
 func (optionsConf *LibcomposeOptionsDownProperty) Description() string {
 	return "Options to configure the Down.  See github.com/docker/libcompose/project/options for more information."
+}
+
+// Is the Property internal only
+func (optionsConf *LibcomposeOptionsDownProperty) Internal() bool {
+	return false
+}
+
+// Give an idea of what type of value the property consumes
+func (optionsConf *LibcomposeOptionsDownProperty) Type() string {
+	return "github.com/docker/libcompose/project/options.Down"
 }
 
 func (optionsConf *LibcomposeOptionsDownProperty) Get() interface{} {

--- a/api/handler/local/api.go
+++ b/api/handler/local/api.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Make a Local based API object, based on a project path
-func MakeLocalAPI(settings LocalAPISettings) *LocalAPI {
+func MakeLocalAPI(settings LocalAPISettings) (*LocalAPI, error) {
 	localAPI := LocalAPI{
 		settings: &settings,
 	}
@@ -117,7 +117,7 @@ func MakeLocalAPI(settings LocalAPISettings) *LocalAPI {
 	// Get an orchestrate wrapper for other handlers
 	localAPI.Command = local_command.CommandWrapper()
 
-	return &localAPI
+	return &localAPI, nil
 }
 
 // Settings needed to make a local API

--- a/api/operation/command/property.go
+++ b/api/operation/command/property.go
@@ -50,6 +50,11 @@ func (confKey *CommandKeyProperty) Description() string {
 	return "Command key."
 }
 
+// Is the Property internal only
+func (confKey *CommandKeyProperty) Internal() bool {
+	return false
+}
+
 // Command for a single command object
 type CommandCommandProperty struct {
 	command Command
@@ -68,6 +73,16 @@ func (com *CommandCommandProperty) Label() string {
 // Description for the Property
 func (com *CommandCommandProperty) Description() string {
 	return "Command object."
+}
+
+// Is the Property internal only
+func (com *CommandCommandProperty) Internal() bool {
+	return true
+}
+
+// Give an idea of what type of value the property consumes
+func (com *CommandCommandProperty) Type() string {
+	return "operation/command.Command"
 }
 
 // Get the Command value
@@ -106,6 +121,11 @@ func (keyValue *CommandKeysProperty) Description() string {
 	return "Command key list."
 }
 
+// Is the Property internal only
+func (keyValue *CommandKeysProperty) Internal() bool {
+	return false
+}
+
 // Command for an ordered list of command keys
 type CommandFlagsProperty struct {
 	operation.StringSliceProperty
@@ -124,6 +144,11 @@ func (keyValue *CommandFlagsProperty) Label() string {
 // Description for the Property
 func (keyValue *CommandFlagsProperty) Description() string {
 	return "An ordered list of string flags to send to a command."
+}
+
+// Is the Property internal only
+func (keyValue *CommandFlagsProperty) Internal() bool {
+	return false
 }
 
 // A command Property for command output
@@ -146,6 +171,11 @@ func (keyValue *CommandOutputProperty) Description() string {
 	return "An io.Writer, which will receive the command execution output.  Any io.writer can be used, the default here will be os.Stdout."
 }
 
+// Is the Property internal only
+func (keyValue *CommandOutputProperty) Internal() bool {
+	return false
+}
+
 // A command Property for command error output
 type CommandErrorProperty struct {
 	operation.WriterProperty
@@ -164,6 +194,11 @@ func (keyValue *CommandErrorProperty) Label() string {
 // Description for the Property
 func (keyValue *CommandErrorProperty) Description() string {
 	return "An io.Writer, which will receive the command execution error output.  Any io.writer can be used, the default here will be os.Stdout."
+}
+
+// Is the Property internal only
+func (keyValue *CommandErrorProperty) Internal() bool {
+	return false
 }
 
 // A command Property for command execution input
@@ -186,6 +221,11 @@ func (keyValue *CommandInputProperty) Description() string {
 	return "An io.Reader, which will provide command execution input.  Any io.reader can be used, the default here will be os.Stdin"
 }
 
+// Is the Property internal only
+func (keyValue *CommandInputProperty) Internal() bool {
+	return false
+}
+
 // A command Property for command execution net context
 type CommandContextProperty struct {
 	operation.ContextProperty
@@ -204,4 +244,9 @@ func (contextConf *CommandContextProperty) Label() string {
 // Description for the Property
 func (contextConf *CommandContextProperty) Description() string {
 	return "A golang.org/x/net/context for controling execution."
+}
+
+// Is the Property internal only
+func (contextConf *CommandContextProperty) Internal() bool {
+	return false
 }

--- a/api/operation/config/property.go
+++ b/api/operation/config/property.go
@@ -46,6 +46,11 @@ func (confKey *ConfigKeyProperty) Description() string {
 	return "property key."
 }
 
+// Is the Property internal only
+func (confKey *ConfigKeyProperty) Internal() bool {
+	return false
+}
+
 // property for an ordered list of config keys
 type ConfigKeysProperty struct {
 	operation.StringSliceProperty
@@ -66,24 +71,34 @@ func (keyValue *ConfigKeysProperty) Description() string {
 	return "property key list."
 }
 
+// Is the Property internal only
+func (keyValue *ConfigKeysProperty) Internal() bool {
+	return false
+}
+
 // property for a single config value
 type ConfigValueProperty struct {
 	operation.BytesArrayProperty
 }
 
 // Id for the property
-func (confValue *ConfigValueProperty) Id() string {
+func (property *ConfigValueProperty) Id() string {
 	return OPERATION_PROPERTY_CONFIG_VALUE
 }
 
 // Label for the property
-func (confValue *ConfigValueProperty) Label() string {
+func (property *ConfigValueProperty) Label() string {
 	return "property value."
 }
 
 // Description for the property
-func (confValue *ConfigValueProperty) Description() string {
+func (property *ConfigValueProperty) Description() string {
 	return "property value."
+}
+
+// Is the Property internal only
+func (property *ConfigValueProperty) Internal() bool {
+	return false
 }
 
 // property for a value as a set of io.Readers
@@ -92,18 +107,28 @@ type ConfigValueScopedReadersProperty struct {
 }
 
 // Id for the property
-func (confValue *ConfigValueScopedReadersProperty) Id() string {
+func (property *ConfigValueScopedReadersProperty) Id() string {
 	return OPERATION_PROPERTY_CONFIG_VALUE_READERS
 }
 
 // Label for the property
-func (confValue *ConfigValueScopedReadersProperty) Label() string {
+func (property *ConfigValueScopedReadersProperty) Label() string {
 	return "Config value readers."
 }
 
 // Description for the property
-func (confValue *ConfigValueScopedReadersProperty) Description() string {
+func (property *ConfigValueScopedReadersProperty) Description() string {
 	return "Config value in the form of an ScopeReaders, which is an ordered map of io.Readers."
+}
+
+// Is the Property internal only
+func (property *ConfigValueScopedReadersProperty) Internal() bool {
+	return false
+}
+
+// Give an idea of what type of value the property consumes
+func (property *ConfigValueScopedReadersProperty) Type() string {
+	return "operation/config.ScopeReaders"
 }
 
 // Retreive the property value
@@ -128,18 +153,28 @@ type ConfigValueScopedWritersProperty struct {
 }
 
 // Id for the property
-func (confValue *ConfigValueScopedWritersProperty) Id() string {
+func (property *ConfigValueScopedWritersProperty) Id() string {
 	return OPERATION_PROPERTY_CONFIG_VALUE_WRITERS
 }
 
 // Label for the property
-func (confValue *ConfigValueScopedWritersProperty) Label() string {
+func (property *ConfigValueScopedWritersProperty) Label() string {
 	return "Config value writers."
 }
 
 // Description for the property
-func (confValue *ConfigValueScopedWritersProperty) Description() string {
+func (property *ConfigValueScopedWritersProperty) Description() string {
 	return "Config value in the form of an io.Writer."
+}
+
+// Is the Property internal only
+func (property *ConfigValueScopedWritersProperty) Internal() bool {
+	return false
+}
+
+// Give an idea of what type of value the property consumes
+func (property *ConfigValueScopedWritersProperty) Type() string {
+	return "operation/config.ScopeWriters"
 }
 
 // Retreive the property value

--- a/api/operation/monitor/log.go
+++ b/api/operation/monitor/log.go
@@ -146,6 +146,11 @@ func (logType *MonitorLogTypeProperty) Description() string {
 	return "Message type, which can be either info or error."
 }
 
+// Is the Property internal only
+func (logType *MonitorLogTypeProperty) Internal() bool {
+	return false
+}
+
 // property for a monitoring log message
 type MonitorLogMessageProperty struct {
 	operation.StringProperty
@@ -164,4 +169,9 @@ func (message *MonitorLogMessageProperty) Label() string {
 // Description for the property
 func (message *MonitorLogMessageProperty) Description() string {
 	return "Message which will be sent to the standard logger."
+}
+
+// Is the Property internal only
+func (message *MonitorLogMessageProperty) Internal() bool {
+	return false
 }

--- a/api/operation/monitor/property.go
+++ b/api/operation/monitor/property.go
@@ -27,3 +27,8 @@ func (output *MonitorOutputProperty) Label() string {
 func (output *MonitorOutputProperty) Description() string {
 	return "Attach an io.Writer to the operation, and it will be used to capture the output.  By default, the output will go to log."
 }
+
+// Is the Property internal only
+func (output *MonitorOutputProperty) Internal() bool {
+	return false
+}

--- a/api/operation/property.go
+++ b/api/operation/property.go
@@ -25,6 +25,11 @@ type Property interface {
 	Label() string
 	// Description provides a longer multi-line string description of what the property does
 	Description() string
+	// Mark a property as being for internal use only (no shown to users)
+	Internal() bool
+
+	// Give an idea of what type of value the property consumes
+	Type() string
 
 	// Value allows the retrieval and setting of unknown Typed values for the property.
 	Get() interface{}

--- a/api/operation/property_base.go
+++ b/api/operation/property_base.go
@@ -19,6 +19,7 @@ type BaseProperty struct {
 	id          string
 	label       string
 	description string
+	internal    bool
 }
 
 // Id returns the string id variable
@@ -31,6 +32,9 @@ func (property *BaseProperty) Label() string {
 }
 func (property *BaseProperty) Description() string {
 	return property.description
+}
+func (property *BaseProperty) Internal() bool {
+	return property.internal
 }
 
 /**
@@ -51,6 +55,11 @@ type StringProperty struct {
 	value string
 }
 
+// Give an idea of what type of value the property consumes
+func (property *StringProperty) Type() string {
+	return "string"
+}
+
 func (property *StringProperty) Get() interface{} {
 	return interface{}(property.value)
 }
@@ -67,6 +76,11 @@ func (property *StringProperty) Set(value interface{}) bool {
 // A base Property that provides a slice of string values
 type StringSliceProperty struct {
 	value []string
+}
+
+// Give an idea of what type of value the property consumes
+func (property *StringSliceProperty) Type() string {
+	return "[]string"
 }
 
 func (property *StringSliceProperty) Get() interface{} {
@@ -87,6 +101,11 @@ type BytesArrayProperty struct {
 	value []byte
 }
 
+// Give an idea of what type of value the property consumes
+func (property *BytesArrayProperty) Type() string {
+	return "[]byte"
+}
+
 func (property *BytesArrayProperty) Get() interface{} {
 	return interface{}(property.value)
 }
@@ -105,6 +124,11 @@ type BooleanProperty struct {
 	value bool
 }
 
+// Give an idea of what type of value the property consumes
+func (property *BooleanProperty) Type() string {
+	return "bool"
+}
+
 func (property *BooleanProperty) Get() interface{} {
 	return interface{}(property.value)
 }
@@ -121,6 +145,11 @@ func (property *BooleanProperty) Set(value interface{}) bool {
 // A base Property that provides an IO.Writer
 type WriterProperty struct {
 	value io.Writer
+}
+
+// Give an idea of what type of value the property consumes
+func (property *WriterProperty) Type() string {
+	return "io.Writer"
 }
 
 func (property *WriterProperty) Get() interface{} {
@@ -147,6 +176,11 @@ type ReaderProperty struct {
 	value io.Reader
 }
 
+// Give an idea of what type of value the property consumes
+func (property *ReaderProperty) Type() string {
+	return "io.Reader"
+}
+
 func (property *ReaderProperty) Get() interface{} {
 	if property.value == nil {
 		property.value = io.Reader(os.Stdin)
@@ -166,6 +200,11 @@ func (property *ReaderProperty) Set(value interface{}) bool {
 // A base Property that provides an net context
 type ContextProperty struct {
 	value context.Context
+}
+
+// Give an idea of what type of value the property consumes
+func (property *ContextProperty) Type() string {
+	return "golang.org/x/net/context.Context"
 }
 
 // Retrieve the context, or retrieve a Background context by default

--- a/api/operation/setting/property.go
+++ b/api/operation/setting/property.go
@@ -40,6 +40,11 @@ func (key *SettingKeyProperty) Description() string {
 	return "Setting string key."
 }
 
+// Is the Property internal only
+func (key *SettingKeyProperty) Internal() bool {
+	return false
+}
+
 // Property for a single setting scope
 type SettingScopeProperty struct {
 	operation.StringProperty
@@ -58,6 +63,11 @@ func (scope *SettingScopeProperty) Label() string {
 // Description for the Property
 func (scope *SettingScopeProperty) Description() string {
 	return "Property string scope."
+}
+
+// Is the Property internal only
+func (scope *SettingScopeProperty) Internal() bool {
+	return false
 }
 
 // Property for an ordered list of config keys
@@ -80,6 +90,11 @@ func (keys *SettingKeysProperty) Description() string {
 	return "Property key list."
 }
 
+// Is the Property internal only
+func (keys *SettingKeysProperty) Internal() bool {
+	return false
+}
+
 // Property for a single config value
 type SettingValueProperty struct {
 	operation.BytesArrayProperty
@@ -98,4 +113,9 @@ func (settingValue *SettingValueProperty) Label() string {
 // Description for the Property
 func (settingValue *SettingValueProperty) Description() string {
 	return "Property value."
+}
+
+// Is the Property internal only
+func (settingValue *SettingValueProperty) Internal() bool {
+	return false
 }

--- a/cli/local/api.go
+++ b/cli/local/api.go
@@ -19,6 +19,7 @@ const (
 )
 
 func MakeLocalAPI() (*api_local.LocalAPI, error) {
+	var err error
 
 	workingDir, _ := os.Getwd()
 	settings := api_local.LocalAPISettings{
@@ -40,9 +41,12 @@ func MakeLocalAPI() (*api_local.LocalAPI, error) {
 	 * project level confs
 	 */
 
-	API := api_local.MakeLocalAPI(settings)
+	if API, makeErr := api_local.MakeLocalAPI(settings); makeErr != nil {
+		return API, makeErr
+	} else {
+		return API, err
+	}
 
-	return API, nil
 }
 
 // a quick snippet to discover a user's home folder
@@ -62,7 +66,7 @@ func userHomePath() string {
  * dependening on OS, determine if the user has any settings
  * if so, add a conf path for them.
  */
-func DiscoverUserPaths(settings *api_local.LocalAPISettings) {
+func DiscoverUserPaths(settings *api_local.LocalAPISettings) error {
 	homeDir := userHomePath()
 	homeWTDir := path.Join(homeDir, WUNDERTOOLS_PROJECT_CONF_FOLDER)
 
@@ -79,6 +83,8 @@ func DiscoverUserPaths(settings *api_local.LocalAPISettings) {
 	 */
 	settings.UserHomePath = homeDir
 	settings.ConfigPaths.Set("user-wundertools", homeWTDir)
+
+	return nil
 }
 
 /**
@@ -88,7 +94,7 @@ func DiscoverUserPaths(settings *api_local.LocalAPISettings) {
  * has the key configuration subfolder in it.  That path is marked as the
  * application root, and the subfolder is marked as a conf path
  */
-func DiscoverProjectPaths(settings *api_local.LocalAPISettings) {
+func DiscoverProjectPaths(settings *api_local.LocalAPISettings) error {
 	workingDir := settings.ExecPath
 	homeDir := userHomePath()
 
@@ -110,4 +116,6 @@ RootSearch:
 	 */
 	settings.ProjectRootPath = projectRootDirectory
 	settings.ConfigPaths.Set("project-wundertools", path.Join(projectRootDirectory, WUNDERTOOLS_PROJECT_CONF_FOLDER))
+
+	return nil
 }

--- a/cli/local/local.go
+++ b/cli/local/local.go
@@ -14,9 +14,9 @@ import (
 /**
  * Add Local Commands to the app
  */
-func AppLocalCommands(app *cli.App) {
+func AppLocalCommands(app *cli.App) error {
 
-	local, _ := MakeLocalAPI()
+	local, err := MakeLocalAPI()
 
 	// get all of the operations
 	ops := local.Operations()
@@ -69,6 +69,7 @@ func AppLocalCommands(app *cli.App) {
 		log.WithError(err).Error("Failed to list commands")
 	}
 
+	return err
 }
 
 /**
@@ -81,6 +82,8 @@ type CliOperationWrapper struct {
 // Execute the operation for the cli
 func (opWrapper *CliOperationWrapper) Exec(cliContext *cli.Context) error {
 	log.WithFields(log.Fields{"id": opWrapper.op.Id()}).Debug("Running operation")
+
+	CliAssignPropertiesFromFlags(cliContext, opWrapper.op.Properties())
 
 	if success, errs := opWrapper.op.Exec().Success(); !success {
 		var err error
@@ -104,6 +107,8 @@ type CliCommandWrapper struct {
 // Execute the operation for the cli
 func (commWrapper *CliCommandWrapper) Exec(cliContext *cli.Context) error {
 	log.WithFields(log.Fields{"id": commWrapper.comm.Id()}).Debug("Running command")
+
+	CliAssignPropertiesFromFlags(cliContext, commWrapper.comm.Properties())
 
 	if success, errs := commWrapper.comm.Exec().Success(); !success {
 		var err error


### PR DESCRIPTION
This patch refactors properties to include Internal() and Type(), to make them more usable for interactions with users.
